### PR TITLE
Fix Oscar Document (22.01) reexports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oscar-io"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Readers/Writers for OSCAR Corpora."
 documentation = "https://docs.rs/oscar-io"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ schemars = "0.8.8"
 serde = "1.0.136"
 serde_json = "1.0.79"
 warc = { version = "0.3.1", features = ["with_serde"]}
-#[derive(Serialize, Deserialize)]
 
 avro-rs = { version = "0.13.0", features = ["snappy"]}
 oxilangtag = { version = "0.1.3", features = ["serde"]}

--- a/src/oscar_doc/mod.rs
+++ b/src/oscar_doc/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Each document is materialized by a [Document], holding [Metadata], [WarcHeaders] and `content` (that is a [String]).
 mod reader;
-// mod types;
+mod types;
 mod writer;
 
 #[cfg(feature = "avro")]
@@ -10,7 +10,7 @@ pub use reader::AvroDocReader as AvroReader;
 pub use reader::DocReader as Reader;
 pub use reader::SplitFileIter as SplitReader;
 pub use reader::SplitFolderFileIter as SplitFolderReader;
-// pub use types::Document;
-// pub use types::Metadata;
-// pub use types::WarcHeaders;
+pub use types::Document;
+pub use types::Metadata;
+pub use types::WarcHeaders;
 pub use writer::DocWriter as Writer;

--- a/src/oscar_doc/types/document.rs
+++ b/src/oscar_doc/types/document.rs
@@ -26,7 +26,7 @@ impl Document {
     /// Instantiate a Document from a record and a related metadata.
 
     /// Get a reference to the Document's identification
-    pub fn identification(&self) -> &Identification {
+    pub fn identification(&self) -> &Identification<String> {
         self.metadata().identification()
     }
 

--- a/src/oscar_doc/types/metadata.rs
+++ b/src/oscar_doc/types/metadata.rs
@@ -1,24 +1,24 @@
-use schemars::JsonSchema;
+use oxilangtag::LanguageTag;
 use serde::{Deserialize, Serialize};
 
-use crate::{common::Identification, lang::Lang};
+use crate::common::Identification;
 
 /// OSCAR Metadata.
 /// Contains document identification, annotations and sentence-level identifications.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Metadata {
-    identification: Identification,
+    identification: Identification<String>,
     annotation: Option<Vec<String>>,
-    sentence_identifications: Vec<Option<Identification>>,
+    sentence_identifications: Vec<Option<Identification<String>>>,
 }
 
 impl Metadata {
     /// Create a new [Metadata].
     /// Internally clones provided parameters
     pub fn new(
-        identification: &Identification,
+        identification: &Identification<String>,
         annotation: &Option<Vec<String>>,
-        sentence_identifications: &[Option<Identification>],
+        sentence_identifications: &[Option<Identification<String>>],
     ) -> Self {
         Metadata {
             identification: identification.clone(),
@@ -36,7 +36,7 @@ impl Metadata {
     }
 
     /// Get a reference to the identification
-    pub fn identification(&self) -> &Identification {
+    pub fn identification(&self) -> &Identification<String> {
         &self.identification
     }
 
@@ -50,10 +50,11 @@ impl Default for Metadata {
     /// default Metadata is English with 1.0 prob,
     /// no annotation and a single english sentence with 1.0 prob.
     fn default() -> Self {
+        let default_tag = LanguageTag::parse("en".to_string()).unwrap();
         Self {
-            identification: Identification::new(Lang::En, 1.0),
+            identification: Identification::new(default_tag.clone(), 1.0),
             annotation: None,
-            sentence_identifications: vec![Some(Identification::new(Lang::En, 1.0))],
+            sentence_identifications: vec![Some(Identification::new(default_tag, 1.0))],
         }
     }
 }


### PR DESCRIPTION
Missing reexports. 

Had to drop JsonSchema derive for it to work.